### PR TITLE
INT-1440:  ThreatConnect Case Updates (Ed Edits)

### DIFF
--- a/components/threatconnect.js
+++ b/components/threatconnect.js
@@ -258,7 +258,6 @@ polarity.export = PolarityComponent.extend({
       const path = `indicators.${indicatorId}.indicator.__newCase`;
       this.set(`${path}.__selectedWorkflowData`, null);
     },
-
     confirmRemoveDescription(indicatorId) {
       const path = `indicators.${indicatorId}.indicator.__newCase`;
       const modalData = this.get(`${path}.__selectedWorkflowData`);
@@ -387,40 +386,15 @@ polarity.export = PolarityComponent.extend({
         this.set(`${fullPath}.__errorMessage`, '');
       }
     },
-    onWorkflowTemplateInput(indicatorId, event) {
-      const inputValue = event.target.value;
-      const path = `indicators.${indicatorId}.indicator.__newCase`;
-      const templates = this.get(`${path}.workflowTemplates`) || [];
-
-      if (inputValue === 'None') {
-        this.set(`${path}.workflowTemplate`, '');
-        this.set(`${path}.workflowTemplateName`, 'None');
-        this.set(`${path}.__selectedWorkflowData`, null);
-      } else {
-        const selected = templates.find((t) => t.name === inputValue);
-
-        if (selected) {
-          this.set(`${path}.workflowTemplate`, selected.id);
-          this.set(`${path}.workflowTemplateName`, selected.name);
-          this.set(`${path}.__selectedWorkflowData`, selected);
-        } else {
-          this.set(`${path}.workflowTemplate`, '');
-          this.set(`${path}.workflowTemplateName`, inputValue);
-          this.set(`${path}.__selectedWorkflowData`, null);
-        }
-      }
-
-      this.notifyPropertyChange(path);
-    },
     createCase(indicatorId, event) {
       event.preventDefault();
 
       const indicatorPath = `indicators.${indicatorId}.indicator`;
       const newCasePath = `${indicatorPath}.__newCase`;
       let newCase = this.get(newCasePath) || {};
-
+      
       const name = newCase.name ? newCase.name.trim() : '';
-      const workflowTemplate = newCase.workflowTemplate;
+      const workflowTemplateId = newCase.__selectedWorkflowId;
       const tags = newCase.tags || '';
       const description = newCase.description || '';
       const severity = newCase.severity || 'Low';
@@ -442,7 +416,7 @@ polarity.export = PolarityComponent.extend({
       const payload = {
         action: 'CREATE_CASE',
         name,
-        workflowTemplate,
+        workflowTemplateId,
         description,
         tags,
         severity,
@@ -483,7 +457,7 @@ polarity.export = PolarityComponent.extend({
           const newCaseReset = this.get(newCasePath);
           if (newCaseReset) {
             Ember.set(newCaseReset, 'name', '');
-            Ember.set(newCaseReset, 'workflowTemplate', '');
+            Ember.set(newCaseReset, 'workflowTemplateId', '');
             Ember.set(newCaseReset, 'description', '');
             Ember.set(newCaseReset, 'tags', '');
             Ember.set(newCaseReset, 'severity', 'Low');

--- a/components/threatconnect.js
+++ b/components/threatconnect.js
@@ -254,20 +254,6 @@ polarity.export = PolarityComponent.extend({
 
       Ember.set(caseToUpdate, '__newAttributes', updatedAttributes);
     },
-    cancelRemoveDescription(indicatorId) {
-      const path = `indicators.${indicatorId}.indicator.__newCase`;
-      this.set(`${path}.__selectedWorkflowData`, null);
-    },
-    confirmRemoveDescription(indicatorId) {
-      const path = `indicators.${indicatorId}.indicator.__newCase`;
-      const modalData = this.get(`${path}.__selectedWorkflowData`);
-
-      if (modalData) {
-        this.set(`${path}.description`, modalData.templateDescription || '');
-      }
-
-      this.set(`${path}.__selectedWorkflowData`, null);
-    },
     updateNewCaseField(indicatorId, field, event) {
       const value = field === 'associateIndicator' ? event.target.checked : event.target.value;
       const path = `indicators.${indicatorId}.indicator.__newCase`;
@@ -386,15 +372,34 @@ polarity.export = PolarityComponent.extend({
         this.set(`${fullPath}.__errorMessage`, '');
       }
     },
+    onWorkflowTemplateChange(indicatorId, workflowId) {
+      const path = `indicators.${indicatorId}.indicator.__newCase`;
+      const templates = this.get(`${path}.workflowTemplates`) || [];
+
+      if (workflowId === 'none') {
+        this.set(`${path}.__selectedWorkflowData`, null);
+        this.set(`${path}.__showNewCaseChangeDescriptionModal`, false);
+      } else {
+        const selectedWorkflow = templates.find((t) => t.id.toString() === workflowId);
+        
+        if (selectedWorkflow) {
+          this.set(`${path}.__selectedWorkflowData`, selectedWorkflow);
+          this.set(`${path}.__showNewCaseChangeDescriptionModal`, true);
+        } else {
+          this.set(`${path}.__selectedWorkflowData`, null);
+          this.set(`${path}.__showNewCaseChangeDescriptionModal`, false);
+        }
+      }
+    },
     createCase(indicatorId, event) {
       event.preventDefault();
 
       const indicatorPath = `indicators.${indicatorId}.indicator`;
       const newCasePath = `${indicatorPath}.__newCase`;
       let newCase = this.get(newCasePath) || {};
-      
+
       const name = newCase.name ? newCase.name.trim() : '';
-      const workflowTemplateId = newCase.__selectedWorkflowId;
+      const workflowTemplateId = newCase.__selectedWorkflowData.id;
       const tags = newCase.tags || '';
       const description = newCase.description || '';
       const severity = newCase.severity || 'Low';
@@ -416,7 +421,7 @@ polarity.export = PolarityComponent.extend({
       const payload = {
         action: 'CREATE_CASE',
         name,
-        workflowTemplateId,
+        workflowTemplate,
         description,
         tags,
         severity,
@@ -457,7 +462,7 @@ polarity.export = PolarityComponent.extend({
           const newCaseReset = this.get(newCasePath);
           if (newCaseReset) {
             Ember.set(newCaseReset, 'name', '');
-            Ember.set(newCaseReset, 'workflowTemplateId', '');
+            Ember.set(newCaseReset, 'workflowTemplate', '');
             Ember.set(newCaseReset, 'description', '');
             Ember.set(newCaseReset, 'tags', '');
             Ember.set(newCaseReset, 'severity', 'Low');

--- a/components/threatconnect.js
+++ b/components/threatconnect.js
@@ -421,7 +421,7 @@ polarity.export = PolarityComponent.extend({
       const payload = {
         action: 'CREATE_CASE',
         name,
-        workflowTemplate,
+        workflowTemplateId,
         description,
         tags,
         severity,
@@ -430,7 +430,7 @@ polarity.export = PolarityComponent.extend({
         associateIndicator: associate,
         indicatorId
       };
-
+      
       this.set(`${indicatorPath}.__isCreatingCase`, true);
 
       this.sendIntegrationMessage(payload)

--- a/config/config.json
+++ b/config/config.json
@@ -3,7 +3,7 @@
   "name": "ThreatConnect",
   "acronym": "TC",
   "logging": {
-    "level": "info"
+    "level": "trace"
   },
   "entityTypes": ["IPv4", "IPv6", "MD5", "SHA1", "SHA256", "email", "domain", "url"],
   "description": "Polarity integration that searches indicators in the ThreatConnect threat intelligence platform",

--- a/src/queries/create-case.js
+++ b/src/queries/create-case.js
@@ -20,9 +20,9 @@ async function createCase(payload, options) {
     requestOptions.body.name = name;
   }
 
-  const workflowTemplate = payload.workflowTemplate;
-  if (workflowTemplate && workflowTemplate !== 'undefined') {
-    requestOptions.body.workflowTemplate = { id: parseInt(workflowTemplate, 10) };
+  const workflowTemplateId = parseInt(payload.workflowTemplateId, 10);
+  if (!Number.isNaN(workflowTemplateId)) {
+    requestOptions.body.workflowTemplate = { id: workflowTemplateId };
   }
 
   const description = payload.description;

--- a/templates/threatconnect.hbs
+++ b/templates/threatconnect.hbs
@@ -999,32 +999,30 @@
                     {{/if}}
 
                     <div class="form-group">
-                      <label for="workflowTemplate-{{indicatorId}}">
-                        Workflow Template
-                        {{#if orgData.indicator.__newCase.__isLoadingTemplates}}
-                          <span class="p-footnote">
-                            {{fa-icon icon="spinner-third" spin=true fixedWidth=true}}
-                            Loading...
-                          </span>
-                        {{/if}}
-                      </label>
-                      <input
-                        list="workflowTemplateList-{{indicatorId}}"
-                        id="workflowTemplate-{{indicatorId}}"
-                        class="form-control-new-case"
-                        value={{orgData.indicator.__newCase.workflowTemplateName}}
-                        disabled={{or
-                          orgData.indicator.__isCreatingCase
-                          orgData.indicator.__newCase.__isLoadingTemplates
-                        }}
-                        {{on "input" (action "onWorkflowTemplateInput" indicatorId)}}
-                      />
-                      <datalist id="workflowTemplateList-{{indicatorId}}">
-                        <option value="None" />
-                        {{#each orgData.indicator.__newCase.workflowTemplates as |template|}}
-                          <option value="{{template.name}}" />
-                        {{/each}}
-                      </datalist>
+                      {{#let orgData.indicator.__newCase as | newCase |}}
+                        <label>
+                          Workflow Template
+                          {{#if newCase.__isLoadingTemplates}}
+                            <span class="p-footnote">
+                              {{fa-icon icon="spinner-third" spin=true fixedWidth=true}}
+                              Loading...
+                            </span>
+                          {{/if}}
+                        </label>
+                        <select 
+                          class="form-control-new-case" 
+                          onchange={{action (mut newCase.__selectedWorkflowId) value="target.value"}} 
+                          disabled={{or orgData.indicator.__isCreatingCase newCase.__isLoadingTemplates}}
+                        >
+                          <option value="none">None</option>
+                          {{#each newCase.workflowTemplates as | template |}}
+                            {{!-- `concat` helper is require to coerce the `template.id` into a string --}}
+                            <option value="{{template.id}}" selected={{eq (concat template.id "") newCase.__selectedWorkflowId}}>
+                              {{template.name}}
+                            </option>
+                          {{/each}}
+                        </select>
+                      {{/let}}
                     </div>
 
                     {{#if orgData.indicator.__newCase.__selectedWorkflowData}}

--- a/templates/threatconnect.hbs
+++ b/templates/threatconnect.hbs
@@ -966,10 +966,7 @@
                         }}
                         value={{orgData.indicator.__newCase.name}}
                         required
-                        disabled={{or
-                          orgData.indicator.__isCreatingCase
-                          orgData.indicator.__newCase.__selectedWorkflowData
-                        }}
+                        disabled={{orgData.indicator.__isCreatingCase}}
                         {{on "input" (action "updateNewCaseField" indicatorId "name")}}
                       />
                       {{#if orgData.indicator.__newCase.__error}}
@@ -997,9 +994,8 @@
                         </div>
                       </div>
                     {{/if}}
-
-                    <div class="form-group">
-                      {{#let orgData.indicator.__newCase as | newCase |}}
+                    {{#let orgData.indicator.__newCase as | newCase |}}
+                      <div class="form-group">
                         <label>
                           Workflow Template
                           {{#if newCase.__isLoadingTemplates}}
@@ -1009,42 +1005,42 @@
                             </span>
                           {{/if}}
                         </label>
-                        <select 
-                          class="form-control-new-case" 
-                          onchange={{action (mut newCase.__selectedWorkflowId) value="target.value"}} 
+                        <select
+                          class="form-control-new-case"
+                          onchange={{action (action "onWorkflowTemplateChange" indicatorId) value="target.value"}}
                           disabled={{or orgData.indicator.__isCreatingCase newCase.__isLoadingTemplates}}
                         >
                           <option value="none">None</option>
                           {{#each newCase.workflowTemplates as | template |}}
-                            {{!-- `concat` helper is require to coerce the `template.id` into a string --}}
-                            <option value="{{template.id}}" selected={{eq (concat template.id "") newCase.__selectedWorkflowId}}>
+                            <option value="{{template.id}}" selected={{eq template.id newCase.__selectedWorkflowData.id}}>
                               {{template.name}}
                             </option>
                           {{/each}}
                         </select>
-                      {{/let}}
-                    </div>
+                      </div>
 
-                    {{#if orgData.indicator.__newCase.__selectedWorkflowData}}
-                      <div class="ioc-deletion-modal">
-                        <div class="note">
-                          <span class="p-key">
-                            <span class="p-value"><em><b>WARNING:</b></em></span>
-                            <div>
-                              <span>The template you selected has a different description than your Case.</span>
+                      {{#if orgData.indicator.__newCase.__showNewCaseChangeDescriptionModal}}
+                        <div class="ioc-deletion-modal">
+                          <div class="note">
+                            <span class="p-key">
+                              <span class="p-value"><em><b>WARNING:</b></em></span>
+                              <div>
+                                <span>The template you selected has a different description than your Case.</span>
+                              </div>
+                              <div>
+                                <span>Do you want to keep the current description?</span>
+                              </div>
+                            </span>
+                            <div class="delete-confirmation-button">
+                              <button class="confirm-delete" {{action (pipe-action (set newCase "description" newCase.__selectedWorkflowData.description)(set newCase "__showNewCaseChangeDescriptionModal" false))}}>
+                                Use Template
+                              </button>
+                              <button class="cancel-delete" {{action (set newCase "__showNewCaseChangeDescriptionModal" false)}}>Keep Current</button>
                             </div>
-                            <div>
-                              <span>Do you want to keep the current description?</span>
-                            </div>
-                          </span>
-                          <div class="delete-confirmation-button">
-                            <button class="confirm-delete" {{action "confirmRemoveDescription" indicatorId}}>Use
-                              Template</button>
-                            <button class="cancel-delete" {{action "cancelRemoveDescription" indicatorId}}>Keep Current</button>
                           </div>
                         </div>
-                      </div>
-                    {{/if}}
+                      {{/if}}
+                    {{/let}}
 
                     <div class="form-group">
                       <label class="small ifta-label">
@@ -1054,10 +1050,7 @@
                         class="form-control-new-case ifta-field"
                         rows="4"
                         value={{orgData.indicator.__newCase.description}}
-                        disabled={{or
-                          orgData.indicator.__isCreatingCase
-                          orgData.indicator.__newCase.__selectedWorkflowData
-                        }}
+                        disabled={{orgData.indicator.__isCreatingCase}}
                         {{on "input" (action "updateNewCaseField" indicatorId "description")}}
                       ></textarea>
                     </div>
@@ -1070,10 +1063,7 @@
                         type="text"
                         class="form-control-new-case ifta-field"
                         value={{orgData.indicator.__newCase.tags}}
-                        disabled={{or
-                          orgData.indicator.__isCreatingCase
-                          orgData.indicator.__newCase.__selectedWorkflowData
-                        }}
+                        disabled={{orgData.indicator.__isCreatingCase}}
                         {{on "input" (action "updateNewCaseField" indicatorId "tags")}}
                       />
                     </div>
@@ -1083,11 +1073,8 @@
                     >
                       <div class="form-group" style="flex: 1; margin-right: 5px;">
                         <label for="case-severity">Severity</label>
-                        <select
-                          disabled={{or
-                            orgData.indicator.__isCreatingCase
-                            orgData.indicator.__newCase.__selectedWorkflowData
-                          }}
+                        <select 
+                          disabled={{orgData.indicator.__isCreatingCase}}
                           id="case-severity"
                           class="form-control-new-case"
                           value={{orgData.indicator.__newCase.severity}}
@@ -1103,10 +1090,7 @@
                       <div class="form-group" style="flex: 1; margin-left: 5px;">
                         <label for="case-status">Status</label>
                         <select
-                          disabled={{or
-                            orgData.indicator.__isCreatingCase
-                            orgData.indicator.__newCase.__selectedWorkflowData
-                          }}
+                          disabled={{orgData.indicator.__isCreatingCase}}
                           id="case-status"
                           class="form-control-new-case"
                           value={{orgData.indicator.__newCase.status}}
@@ -1126,20 +1110,14 @@
                         class="form-control-new-case ifta-field"
                         rows="2"
                         value={{orgData.indicator.__newCase.notes}}
-                        disabled={{or
-                          orgData.indicator.__isCreatingCase
-                          orgData.indicator.__newCase.__selectedWorkflowData
-                        }}
+                        disabled={{orgData.indicator.__isCreatingCase}}
                         {{on "input" (action "updateNewCaseField" indicatorId "notes")}}
                       ></textarea>
                     </div>
 
                     <div class="checkbox-new-case">
                       <input
-                        disabled={{or
-                          orgData.indicator.__isCreatingCase
-                          orgData.indicator.__newCase.__selectedWorkflowData
-                        }}
+                        disabled={{orgData.indicator.__isCreatingCase}}
                         type="checkbox"
                         id="associate-indicator"
                         class="form-check-input-new-case"


### PR DESCRIPTION
This is a PR on https://github.com/polarityio/threatconnect/pull/46

1. Switch to a `<select>` element for the workflow templates so users can't type in their own template names (we can revisit this if being able to arbitrarily type in a template name was a requirement).

2. Simplified implementation by reducing variables down to a single `__selectedWorkflowData` which contains the selected workflow data (selected from the dropdown), as well as a `__showNewCaseChangeDescriptionModal` boolean which is set to `true` when we want to show the "New Case Change Description" modal.   I felt having just these two variables was easier to understand what each variables intended purpose was. 

3. Only send the workflow ID to the server.  Since the `id` is the only value we need during case creation we don't send any extraneous information.

